### PR TITLE
Fix for npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internet-archive",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "a module for accessing the Internet Archive API",
   "main": "./lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Added `.npmignore` file to fix the exclusion of the `lib` folder; otherwise, the output of the TypeScript in the NPM package will be omitted.